### PR TITLE
Default to not fail on errors and add option to turn it on.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Below is an example:
    ```
 - If you have the need to add a **test** or add **multiple** property volumes in one application you can 
   override the volume mount point. To do this we can supply a value for the defaulted volume folder in the api
-  i.e `addTo( config, 'some/other/folder/secrets')`. 
+  i.e `addTo( config, {mountPoint:'some/other/folder/secrets'})`. 
   
 - The **last folder name** is used as the prefix for the properties in the configuration 
   e.g. `/mnt/secrets` the properties start with `secrets`,  `/mnt/certs` the properties start with `certs`.
@@ -68,7 +68,7 @@ Below is an example:
 - If you mount volumes with the same last folder name e.g `/mnt/super/secrets` and `/mnt/silly/secrets`
   the properties will be fully merged together into the configuration object under `secrets` and the last property 
   volume that is merged in will override any properties with the same name.
-
+ 
 ## Quick start
 ```bash
 $ yarn add @hmcts/properties-volume
@@ -83,5 +83,17 @@ propertiesVolume.addTo(config)
 
 ### Javascript
 ```javascript
-config = require('properties-volume').addTo(require('config'))
+config = require('@hmcts/properties-volume').addTo(require('config'))
 ```
+ 
+### Options
+The properties volume can be supplied with a couple of options via a _js_ like options object.
+e.g.
+```javascript
+const config = require('@hmcts/properties-volume').addTo(require('config'),{mountPoint:'some/properties/mount/point'})
+```
+
+| Option | Description | Default | 
+| ------ | ----------- | ------- |
+| `mountPoint` | the folder where the properties volume exists. | `/mnt/secrets/`| 
+| `failOnError` | Should this module throw an exception if mount does not exist or there is an error reading the properties | `false` | 

--- a/__tests__/propertyVolumeTests.ts
+++ b/__tests__/propertyVolumeTests.ts
@@ -3,13 +3,13 @@ process.env['NODE_CONFIG_DIR'] = __dirname + '/config/'
 import * as properties from '../src'
 import * as config from 'config'
 
-properties.addTo(config, '__tests__/testVolumes/testVol')
-properties.addTo(config, '__tests__/testVolumes/secrets')
+properties.addTo(config, {mountPoint: '__tests__/testVolumes/testVol'})
+properties.addTo(config, {mountPoint: '__tests__/testVolumes/secrets'})
 
 describe('Read properties from files on a mount or folder.', () => {
-  test('should start have secrets read from volume', () => {
+  test('should start with secrets read from volume', () => {
     const testConfig: any = {}
-    const theConfig = properties.addTo(testConfig, '__tests__/testVolumes/secrets')
+    const theConfig = properties.addTo(testConfig, {mountPoint: '__tests__/testVolumes/secrets' })
     expect(testConfig['secrets']['vaultOne']['secret-one']).toBe('vaultOne.secret-one')
     expect(testConfig['secrets']['vaultOne']['secret_Three']).toBe('vaultOne.secret_Three')
     expect(testConfig['secrets']['vaultTwo']['secret-one']).toBe('vaultTwo.secret-one')
@@ -35,5 +35,9 @@ describe('Read properties from files on a mount or folder.', () => {
     expect(config.get('secrets.vaultTwo.secret-default')).toBe('default2')
     expect(config.get('secrets.someOther_vault.secret-default')).toBe('someother')
   })
-
+  test('should have defaults (existing properties) if not overridden', () => {
+    expect(config.get('secrets.vaultOne.secret-default')).toBe('default')
+    expect(config.get('secrets.vaultTwo.secret-default')).toBe('default2')
+    expect(config.get('secrets.someOther_vault.secret-default')).toBe('someother')
+  })
 })

--- a/__tests__/propertyVolumeTests.ts
+++ b/__tests__/propertyVolumeTests.ts
@@ -9,7 +9,7 @@ properties.addTo(config, {mountPoint: '__tests__/testVolumes/secrets'})
 describe('Read properties from files on a mount or folder.', () => {
   test('should start with secrets read from volume', () => {
     const testConfig: any = {}
-    const theConfig = properties.addTo(testConfig, {mountPoint: '__tests__/testVolumes/secrets' })
+    const theConfig = properties.addTo(testConfig, { mountPoint: '__tests__/testVolumes/secrets' })
     expect(testConfig['secrets']['vaultOne']['secret-one']).toBe('vaultOne.secret-one')
     expect(testConfig['secrets']['vaultOne']['secret_Three']).toBe('vaultOne.secret_Three')
     expect(testConfig['secrets']['vaultTwo']['secret-one']).toBe('vaultTwo.secret-one')
@@ -37,11 +37,17 @@ describe('Read properties from files on a mount or folder.', () => {
   })
 
   test('should throw correct exception if /mnt/secrets does not exist', () => {
-    expect(() => properties.addTo(config)).toThrowError('ENOENT: no such file or directory, scandir \'/mnt/secrets/\'')
+    expect(() => properties.addTo(config, { failOnError: true }))
+      .toThrowError("properties-volume failed with:'Error: ENOENT: no such file or directory, scandir '/mnt/secrets/'")
   })
 
-  test('should throw error if does not have a folder in the mount Point', () => {
-    expect(() => properties.addTo(config,'/')).toThrowError('Invalid properties mount point supplied: \'/\'')
+  test('should not throw exception if failOnError is false', () => {
+    properties.addTo(config, { failOnError: false })
+  })
+
+  test('should throw error if does not have a folder in the mountPoint path', () => {
+    expect(() => properties.addTo(config,{ mountPoint: '/', failOnError: true }))
+      .toThrowError('Invalid properties mount point supplied: \'/\'')
   })
 
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/properties-volume",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Azure key-vault flex volume to express properties integration",
   "license": "MIT",
   "repository": "https://github.com/hmcts/properties-volume-nodejs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/properties-volume",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Azure key-vault flex volume to express properties integration",
   "license": "MIT",
   "repository": "https://github.com/hmcts/properties-volume-nodejs",

--- a/src/Properties.ts
+++ b/src/Properties.ts
@@ -25,7 +25,7 @@ export function addTo (config: any, givenOptions?: Options) {
     if (failOnError) {
       throw Error(`properties-volume failed with:'${error}`)
     }
-    log.info(`Count not read properties from volume: '${mountPoint}' due to '${error}'`)
+    log.info(`Could not read properties from volume: '${mountPoint}' due to '${error}'`)
   }
   return config
 }

--- a/src/Properties.ts
+++ b/src/Properties.ts
@@ -2,13 +2,9 @@ import { Logger } from '@hmcts/nodejs-logging'
 import merge = require('lodash.merge')
 import * as path from 'path'
 import * as fs from 'fs'
+import { Options } from './index'
 
 const log = Logger.getLogger('applicationRunner')
-
-interface Options {
-  mountPoint?: fs.PathLike
-  failOnError?: boolean
-}
 
 const defaultOptions: Options = {
   mountPoint: '/mnt/secrets/',
@@ -20,7 +16,7 @@ export function addTo (config: any, givenOptions?: Options) {
   const mountPoint: fs.PathLike = options.mountPoint!
   const failOnError: boolean = options.failOnError!
 
-  log.info(`Reading properties from volume: '${mountPoint}'`)
+  log.info(`Attempting to read properties from volume: '${mountPoint}'`)
   try {
     const prefix = getPrefix(mountPoint.toString())
     const properties = readVaults(mountPoint)
@@ -29,7 +25,7 @@ export function addTo (config: any, givenOptions?: Options) {
     if (failOnError) {
       throw Error(`properties-volume failed with:'${error}`)
     }
-    log.info(`Reading properties from volume: '${mountPoint}' FAILED with '${error}'`)
+    log.info(`Count not read properties from volume: '${mountPoint}' due to '${error}'`)
   }
   return config
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,8 @@
+import * as fs from 'fs'
+
+export interface Options {
+  mountPoint?: fs.PathLike
+  failOnError?: boolean
+}
+
 export { addTo } from './Properties'


### PR DESCRIPTION
### Change description ###
With the CMC citizen frontend and the current live deployment if the /mnt/secrets does not exist it will fail the startup of the service.
This is probably how every service will behave so Ive added the option to turn on the fail if mount does not exist and default to **ignore all errors** to enable the coexistence of the live and the AKS secrets configuration
