### PR TITLE
Fixing Lodash vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/properties-volume",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Azure key-vault flex volume to express properties integration",
   "license": "MIT",
   "repository": "https://github.com/hmcts/properties-volume-nodejs",
@@ -24,8 +24,7 @@
   },
   "dependencies": {
     "@hmcts/nodejs-logging": "^3.0.0",
-    "@types/lodash.merge": "^4.6.5",
-    "lodash.merge": "^4.6.1",
+    "lodash": "^4.17.11",
     "path":"^0.12.7"
   },
   "devDependencies": {

--- a/src/Properties.ts
+++ b/src/Properties.ts
@@ -1,8 +1,8 @@
 import { Logger } from '@hmcts/nodejs-logging'
-import merge = require('lodash.merge')
 import * as path from 'path'
 import * as fs from 'fs'
 import { Options } from './index'
+let _ = require('lodash')
 
 const log = Logger.getLogger('applicationRunner')
 
@@ -12,7 +12,7 @@ const defaultOptions: Options = {
 }
 
 export function addTo (config: any, givenOptions?: Options) {
-  const options: Options = merge({}, defaultOptions, givenOptions || {})
+  const options: Options = _.merge({}, defaultOptions, givenOptions || {})
   const mountPoint: fs.PathLike = options.mountPoint!
   const failOnError: boolean = options.failOnError!
 
@@ -20,7 +20,7 @@ export function addTo (config: any, givenOptions?: Options) {
   try {
     const prefix = getPrefix(mountPoint.toString())
     const properties = readVaults(mountPoint)
-    config[prefix] = merge(config[prefix] || {}, properties)
+    config[prefix] = _.merge(config[prefix] || {}, properties)
   } catch (error) {
     if (failOnError) {
       throw Error(`properties-volume failed with:'${error}`)

--- a/src/Properties.ts
+++ b/src/Properties.ts
@@ -2,7 +2,7 @@ import { Logger } from '@hmcts/nodejs-logging'
 import * as path from 'path'
 import * as fs from 'fs'
 import { Options } from './index'
-let _ = require('lodash')
+const { merge } = require('lodash')
 
 const log = Logger.getLogger('applicationRunner')
 
@@ -12,7 +12,7 @@ const defaultOptions: Options = {
 }
 
 export function addTo (config: any, givenOptions?: Options) {
-  const options: Options = _.merge({}, defaultOptions, givenOptions || {})
+  const options: Options = merge({}, defaultOptions, givenOptions || {})
   const mountPoint: fs.PathLike = options.mountPoint!
   const failOnError: boolean = options.failOnError!
 
@@ -20,7 +20,7 @@ export function addTo (config: any, givenOptions?: Options) {
   try {
     const prefix = getPrefix(mountPoint.toString())
     const properties = readVaults(mountPoint)
-    config[prefix] = _.merge(config[prefix] || {}, properties)
+    config[prefix] = merge(config[prefix] || {}, properties)
   } catch (error) {
     if (failOnError) {
       throw Error(`properties-volume failed with:'${error}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,18 +61,6 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-21.1.10.tgz#dcacb5217ddf997a090cc822bba219b4b2fd7984"
   integrity sha512-qDyqzbcyNgW2RgWbl606xCYQ+5fK9khOW5+Hl3wH7RggVES0dB6GcZvpmPs/XIty5qpu1xYCwpiK+iRkJ3xFBw==
 
-"@types/lodash.merge@^4.6.5":
-  version "4.6.5"
-  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.5.tgz#5f782604cc754ff57661c541678a03cfe62cca19"
-  integrity sha512-aVuP20wtk34imEUC+gg/EqXJBdsS4R6yeX1LixjZQT04qQ3AceqgF8BJ84L43nVGTC3YZLpvcioza8yzZFWtIw==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.14.121"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.121.tgz#9327e20d49b95fc2bf983fc2f045b2c6effc80b9"
-  integrity sha512-ORj7IBWj13iYufXt/VXrCNMbUuCTJfhzme5kx9U/UtcIPdJYuvPDUAlHlbNhz/8lKCLy9XGIZnGrqXOtQbPGoQ==
-
 "@types/node@*":
   version "11.9.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.9.4.tgz#ceb0048a546db453f6248f2d1d95e937a6f00a14"
@@ -2362,11 +2350,6 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
-lodash.merge@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
-  integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
 
 lodash@^4.17.11, lodash@^4.17.4:
   version "4.17.11"


### PR DESCRIPTION
Fixing Lodash vulnerability reported as per : https://snyk.io/vuln/SNYK-JS-LODASHMERGE-173732

### JIRA link ###

https://tools.hmcts.net/jira/browse/RPE-1005

### Change description ###

Fixing Lodash vulnerability.
Adding lodash as latest .merge isn't released after 4.6.1.

**Does this PR introduce a breaking change?** <!--(check one with "x") -->
```
[ ] Yes
[x] No
```
