### PR TITLE
Use stat instead of lstat

### DIFF
--- a/src/Properties.ts
+++ b/src/Properties.ts
@@ -58,7 +58,7 @@ function addFile (values: any, file: string, mountPoint: fs.PathLike, dir: strin
 
 function readFile (mountPoint: fs.PathLike, dir: string, file: string): string | undefined {
   const path = mountPoint + '/' + dir + '/' + file
-  if (!fs.lstatSync(path).isDirectory()) {
+  if (!fs.statSync(path).isDirectory()) {
     return fs.readFileSync(path, 'utf8')
   }
 }


### PR DESCRIPTION

Using stat instead of lstat due to issue with symlink pointing to directory:
https://nodejs.org/docs/latest-v14.x/api/fs.html#:~:text=Equivalent%20to%20fsPromises.stat()%20unless%20path%20refers%20to%20a%20symbolic%20link%2C%20in%20which%20case%20the%20link%20itself%20is%20stat-ed%2C%20not%20the%20file%20that%20it%20refers%20to.%20Refer%20to%20the%20POSIX%20lstat(2)%20document%20for%20more%20detail.

We've tested this inside a pod and it works.